### PR TITLE
Update 6 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.Server.nuspec
+++ b/MakoIoT.Device.Services.Server.nuspec
@@ -19,14 +19,14 @@
     <dependencies>
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.50.35966" />
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.39.56355" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.16.11" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.17.1" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.25" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.29" />
       <dependency id="nanoFramework.System.Collections" version="1.5.59" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.86" />
-      <dependency id="nanoFramework.System.Net" version="1.11.27" />
-      <dependency id="nanoFramework.System.Net.Http" version="1.5.175" />
-      <dependency id="nanoFramework.System.Text" version="1.3.16" />
+      <dependency id="nanoFramework.System.IO.Streams" version="1.1.88" />
+      <dependency id="nanoFramework.System.Net" version="1.11.30" />
+      <dependency id="nanoFramework.System.Net.Http" version="1.5.178" />
+      <dependency id="nanoFramework.System.Text" version="1.3.29" />
       <dependency id="nanoFramework.System.Threading" version="1.1.46" />
     </dependencies>
   </metadata>

--- a/Tests/MakoIoT.Device.Services.Server.Test/MakoIoT.Device.Services.Server.Test.nfproj
+++ b/Tests/MakoIoT.Device.Services.Server.Test/MakoIoT.Device.Services.Server.Test.nfproj
@@ -33,17 +33,17 @@
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.50.35966\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib, Version=1.16.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.16.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.17.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.1\lib\mscorlib.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.25.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.25\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=3.0.67.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.67\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=3.0.68.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.68\lib\nanoFramework.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.67\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.68\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/MakoIoT.Device.Services.Server.Test/packages.config
+++ b/Tests/MakoIoT.Device.Services.Server.Test/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Services.Interface" version="1.0.50.35966" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.16.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.17.1" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.25" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="3.0.67" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="nanoFramework.TestFramework" version="3.0.68" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>

--- a/src/MakoIoT.Device.Services.Server/MakoIoT.Device.Services.Server.nfproj
+++ b/src/MakoIoT.Device.Services.Server/MakoIoT.Device.Services.Server.nfproj
@@ -43,8 +43,8 @@
     <Reference Include="MakoIoT.Device.Utilities.String, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.39.56355\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib, Version=1.16.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.16.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.17.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.1\lib\mscorlib.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.25.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.25\lib\nanoFramework.DependencyInjection.dll</HintPath>
@@ -55,17 +55,17 @@
     <Reference Include="nanoFramework.System.Collections, Version=1.5.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.59\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.3.16.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.16\lib\nanoFramework.System.Text.dll</HintPath>
+    <Reference Include="nanoFramework.System.Text, Version=1.3.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.29\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Streams, Version=1.1.86.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.86\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.88.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.88\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net, Version=1.11.27.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.27\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.30.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.30\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.175.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.175\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.178.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.178\lib\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.46.1709, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.46\lib\System.Threading.dll</HintPath>

--- a/src/MakoIoT.Device.Services.Server/packages.config
+++ b/src/MakoIoT.Device.Services.Server/packages.config
@@ -2,14 +2,14 @@
 <packages>
   <package id="MakoIoT.Device.Services.Interface" version="1.0.50.35966" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.39.56355" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.16.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.17.1" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.25" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.29" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.59" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.86" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.27" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.175" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text" version="1.3.16" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.88" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.11.30" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.178" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.3.29" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.46" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.7.115" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.CoreLibrary from 1.16.11 to 1.17.1</br>Bumps nanoFramework.System.IO.Streams from 1.1.86 to 1.1.88</br>Bumps nanoFramework.System.Net from 1.11.27 to 1.11.30</br>Bumps nanoFramework.System.Net.Http from 1.5.175 to 1.5.178</br>Bumps nanoFramework.System.Text from 1.3.16 to 1.3.29</br>Bumps nanoFramework.TestFramework from 3.0.67 to 3.0.68</br>
[version update]

### :warning: This is an automated update. :warning:
